### PR TITLE
adding a .p8 file for APNS Push Configuration

### DIFF
--- a/sendbird_platform_sdk/model/add_apns_push_configuration_data.py
+++ b/sendbird_platform_sdk/model/add_apns_push_configuration_data.py
@@ -89,7 +89,12 @@ class AddApnsPushConfigurationData(ModelNormal):
             'content_available': (bool,),  # noqa: E501
             'mutable_content': (bool,),  # noqa: E501
             'push_sound': (str,),  # noqa: E501
-            'apns_type': (str,),  # noqa: E501
+            'apns_type': (str,),  # noqa: E501 
+            # NEW: Add these for .p8 support
+            'apns_p8': (file_type,),  # noqa: E501
+            'apns_key_id': (str,),  # noqa: E501
+            'apns_team_id': (str,),  # noqa: E501
+            'apns_bundle_id': (str,),  # noqa: E501
         }
 
     @cached_property
@@ -105,7 +110,11 @@ class AddApnsPushConfigurationData(ModelNormal):
         'content_available': 'content_available',  # noqa: E501
         'mutable_content': 'mutable_content',  # noqa: E501
         'push_sound': 'push_sound',  # noqa: E501
-        'apns_type': 'apns_type',  # noqa: E501
+        'apns_type': 'apns_type',  # noqa: E501 
+        'apns_p8': 'apns_p8',
+        'apns_key_id': 'apns_key_id',
+        'apns_team_id': 'apns_team_id',
+        'apns_bundle_id': 'apns_bundle_id',
     }
 
     read_only_vars = {


### PR DESCRIPTION
This PR adds support for .p8 APNS push certificates alongside the existing .p12 flow in the AddApnsPushConfigurationData class.

Problem: The current SDK only accepts .p12 files, but Sendbird’s API endpoint supports both .p12 and .p8.

Solution:

Added new fields (apns_p8, apns_key_id, apns_team_id, apns_bundle_id) for .p8 certificates.

Added validation to ensure only one certificate type (.p12 or .p8) is provided.

Maintain backward compatibility with existing .p12 workflows. 