### PR TITLE
fix: replace deprecated urllib3 getheaders/getheader with headers dict

### DIFF
--- a/sendbird_platform_sdk/rest.py
+++ b/sendbird_platform_sdk/rest.py
@@ -36,11 +36,11 @@ class RESTResponse(io.IOBase):
 
     def getheaders(self):
         """Returns a dictionary of the response headers."""
-        return self.urllib3_response.getheaders()
+        return self.urllib3_response.headers
 
     def getheader(self, name, default=None):
         """Returns a given response header."""
-        return self.urllib3_response.getheader(name, default)
+        return self.urllib3_response.headers.get(name, default)
 
 
 class RESTClientObject(object):


### PR DESCRIPTION
## Problem
urllib3 2.6.0 removed the deprecated HTTPResponse.getheaders() and .getheader()
methods, causing an AttributeError crash for users on urllib3 >= 2.6.0.

## Fix
Replaced all calls to getheaders() with response.headers and getheader(name)
with response.headers.get(name) in rest.py. HTTPHeaderDict (urllib3 2.x) is
already case-insensitive, so behavior is identical.

## Testing
Verified the SDK imports and runs without error on urllib3 2.6.0.

Fixes #26